### PR TITLE
fix: assign correct values to bitmap pixels

### DIFF
--- a/src/lib/Bitmap.ts
+++ b/src/lib/Bitmap.ts
@@ -56,7 +56,7 @@ export class Bitmap {
     if (
       !(!this.data || x < 0 || y < 0 || x >= this.width || y >= this.height)
     ) {
-      this.data[this.bmpPosition(x, y)] = 1;
+      this.data[this.bmpPosition(x, y)] = value;
       if (value) {
         this.sX += x;
         this.sY += y;


### PR DESCRIPTION
Incorrect values were being assigned to Bitmap pixels when generating it.
This PR fixes the issue by assigning correct values to Bitmap pixels when building it.

Suspected incorrect behavior of `QuadTree` mentioned in #4 is actually a side-effect of this issue, rather than an issue with `QuadTree` class itslef.

### Correctly generated bitmap for demo case (3 teapots)
![image](https://user-images.githubusercontent.com/17537040/115973961-0c15e080-a527-11eb-971b-d6256ce46c62.png)

Resolve #4 
